### PR TITLE
Fix a small typo in the sql queries example

### DIFF
--- a/data/SQL Queries.ipynb
+++ b/data/SQL Queries.ipynb
@@ -102,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**, in the above example, we query the PUMS microdata to get the count of individuals by marriage status.  If you run the private query repeatedly, you will see that the answer changes a bit bewteen queries."
+    "**Note**, in the above example, we query the PUMS microdata to get the count of individuals by marriage status.  If you run the private query repeatedly, you will see that the answer changes a bit between queries."
    ]
   },
   {


### PR DESCRIPTION
When going through the examples I noticed this tiny typo and thought I might as well fix it